### PR TITLE
fix: onCustomActions

### DIFF
--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/notification/NotificationManager.kt
@@ -775,9 +775,9 @@ class NotificationManager internal constructor(
         // controls in Android 13, custom actions are implemented to support them
         // https://developer.android.com/about/versions/13/behavior-changes-13#playback-controls
         private val needsCustomActionsToAddMissingButtons = Build.VERSION.SDK_INT >= 33
-        private const val REWIND = "rewind"
-        private const val FORWARD = "forward"
-        private const val STOP = "stop"
+        public const val REWIND = "rewind"
+        public const val FORWARD = "forward"
+        public const val STOP = "stop"
         private const val NOTIFICATION_ID = 1
         private const val CHANNEL_ID = "kotlin_audio_player"
         private val DEFAULT_STOP_ICON =

--- a/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
+++ b/kotlin-audio/src/main/java/com/doublesymmetry/kotlinaudio/players/BaseAudioPlayer.kt
@@ -300,6 +300,14 @@ abstract class BaseAudioPlayer internal constructor(
                     )
                 )
             }
+            // see NotificationManager.kt. onRewind, onFastForward and onStop do not trigger.
+            override fun onCustomAction(action: String?, extras: Bundle?) {
+                when (action) {
+                    NotificationManager.REWIND -> playerToUse.seekBack()
+                    NotificationManager.FORWARD -> playerToUse.seekForward()
+                    NotificationManager.STOP-> playerToUse.stop()
+                }
+            }
         })
 
 
@@ -338,7 +346,7 @@ abstract class BaseAudioPlayer internal constructor(
 
         playerEventHolder.updateAudioPlayerState(AudioPlayerState.IDLE)
     }
-    
+
     public fun getMediaSessionToken(): MediaSessionCompat.Token {
         return mediaSession.sessionToken
     }


### PR DESCRIPTION
rewind, forward and stop are all implemented as customActions, not through ForwardingPlayer. Now RNTP's remoteJumpForward will work